### PR TITLE
Fix bug where density can't be found using qualified naming

### DIFF
--- a/Sources/Assetxport/Assets/Densities.cs
+++ b/Sources/Assetxport/Assets/Densities.cs
@@ -29,7 +29,7 @@
 			}
 
 			var qualified = QualifiedNaming.Match(path);
-			if (qualified.Success && KnownQualifiedNames.TryGetValue(expl.Groups[1].Value, out density))
+			if (qualified.Success && KnownQualifiedNames.TryGetValue(qualified.Groups[1].Value, out density))
 			{
 				return true;
 			}


### PR DESCRIPTION
When using qualified naming for assets (e.g. myimage@xxxhdpi.png) the density could not be found. The regular expression match group of the explicit naming was used instead of the qualified one.