### PR TITLE
Solution for assets with color type SKColorType.Index8

### DIFF
--- a/Sources/Assetxport/Assets/Asset.cs
+++ b/Sources/Assetxport/Assets/Asset.cs
@@ -53,7 +53,14 @@
 			{
 				Log.Write($"[{this.Path} ({this.bitmap.Width}x{this.bitmap.Height})({this.Density}x)] -> Generating [{path} ({width}x{height})]");
 
-				var info = new SKImageInfo(width, height);
+                // SKBitmap.Resize() doesn't support SKColorType.Index8
+                // https://github.com/mono/SkiaSharp/issues/331
+                if (bitmap.ColorType != SKColorType.Bgra8888)
+                {
+                    bitmap.CopyTo(bitmap, SKColorType.Bgra8888);
+                }
+
+                var info = new SKImageInfo(width, height);
 
 				using (var resized = bitmap.Resize(info, SKBitmapResizeMethod.Lanczos3))
 				using (var image = SKImage.FromBitmap(resized))


### PR DESCRIPTION
As per [this thread](https://github.com/mono/SkiaSharp/issues/331) SKBitmap.Resize doesn't support SKColorType.Index8. This change is to implement the solution to copy the bitamp to a supported color type.