### PR TITLE
Fix UWP naming of scaled assets

### DIFF
--- a/Sources/Assetxport/Platforms/UwpPlatform.cs
+++ b/Sources/Assetxport/Platforms/UwpPlatform.cs
@@ -17,7 +17,7 @@
 
 		protected override string GetAssetPath(string name, string extension, string qualifier, double density)
 		{
-			return $"{name}{qualifier}{extension}";
+			return $"{name}.{qualifier}{extension}";
 		}
 	}
 }


### PR DESCRIPTION
File names of scaled assets must include a dot (.) in front of the scale-xxx suffix.